### PR TITLE
[RA-1456] SSL support for Atlas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
 RUN echo "deb http://repos.mesosphere.io/ubuntu trusty main" >/etc/apt/sources.list.d/mesosphere.list
 
 RUN apt-get update && \
-	apt-get install -y mesos=0.27.0-0.2.190.ubuntu1404 \
+	apt-get install -y mesos=1.0.1-2.0.93.ubuntu1404 \
 	ca-certificates \
 	curl
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 set -eux
 
-AURORA_IMAGE_VERSION="v2.1.0"
+AURORA_IMAGE_VERSION="v2.2.0"
 AURORA_RELEASE="0.13.0-medallia-2"
 AURORA_SNAPSHOT="https://github.com/medallia/aurora/archive/rel/${AURORA_RELEASE}.tar.gz"
 AURORA_PACKAGE_BRANCH="0.13.x"

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -eux
 AURORA_IMAGE_VERSION="v2.1.0"
 AURORA_RELEASE="0.13.0-medallia-2"
 AURORA_SNAPSHOT="https://github.com/medallia/aurora/archive/rel/${AURORA_RELEASE}.tar.gz"
-AURORA_PACKAGE_BRANCH="master"
+AURORA_PACKAGE_BRANCH="0.13.x"
 
 AURORA_IMAGE="aurora-scheduler:${AURORA_IMAGE_VERSION}-${AURORA_RELEASE}"
 


### PR DESCRIPTION
Checkout from tag v2.1.0-0.13.0-medallia-2

Changes: 
+ Updated mesos version to SSL enabled 1.0.1
+ Updated aurora-packaging branch to 0.13.x because master version is no longer compatible with Aurora 0.13.0 due to updated gradle version

if this PR is merged, then a new version will need to be pushed for release v2.1.0-0.13.0-medallia-2 at medallia/docker-aurora-scheduler.